### PR TITLE
Add JitPack config

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+ - openjdk16

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,4 @@
-jdk:
- - openjdk16
+before_install:
+  - wget https://raw.githubusercontent.com/sormuras/bach/42aa51f2d4b2d9897debec2d15c751a9ac846208/install-jdk.sh
+  - source install-jdk.sh --feature 16
+  - jshell --version


### PR DESCRIPTION
Currently, the config simply sets the JDK version to 16.
This _should_ allow 0.2.7 to publish on JitPack properly.